### PR TITLE
Fix for health after jumping from the bus

### DIFF
--- a/Raider/GameModes/GameModeBase.hpp
+++ b/Raider/GameModes/GameModeBase.hpp
@@ -80,8 +80,8 @@ public:
         Controller->OnRep_Pawn();
         Controller->Possess(Pawn);
 
-        Pawn->HealthSet->Health.Minimum = 1.0f;
-        Pawn->HealthSet->Shield.Minimum = 1.0f;
+        Pawn->HealthSet->Health.Minimum = this->maxHealth;
+        Pawn->HealthSet->CurrentShield.Minimum = this->maxShield;
 
         Pawn->SetMaxHealth(this->maxHealth);
         Pawn->SetMaxShield(this->maxShield);
@@ -182,7 +182,7 @@ public:
         Pawn->SetMaxShield(this->maxShield);
 
         Pawn->HealthSet->Health.Minimum = 0.0f; // Disables spawn island protection
-        Pawn->HealthSet->Shield.Minimum = 0.0f;
+        Pawn->HealthSet->CurrentShield.Minimum = 0.0f;
 
         Pawn->bReplicateMovement = true;
         Pawn->OnRep_ReplicateMovement();


### PR DESCRIPTION
This fix also ensures that when you get damaged on the spawn island you will no longer lose your health & shield making it more like in real Fortnite.