### PR TITLE
Don't make the player win on the spawn island & don't reset characterparts when initializing pawn by default

### DIFF
--- a/Raider/GameModes/GameModeBase.hpp
+++ b/Raider/GameModes/GameModeBase.hpp
@@ -157,7 +157,7 @@ public:
         return Ret;
     }
 
-    void InitPawn(AFortPlayerControllerAthena* PlayerController, FVector Loc = FVector { 1250, 1818, 3284 }, FQuat Rotation = FQuat(), bool bResetCharacterParts = true)
+    void InitPawn(AFortPlayerControllerAthena* PlayerController, FVector Loc = FVector { 1250, 1818, 3284 }, FQuat Rotation = FQuat(), bool bResetCharacterParts = false)
     {
         if (PlayerController->Pawn)
             PlayerController->Pawn->K2_DestroyActor();

--- a/Raider/UFunctionHooks.h
+++ b/Raider/UFunctionHooks.h
@@ -368,7 +368,7 @@ namespace UFunctionHooks
                     Spectate(DeadPC->NetConnection, KillerPlayerState);
                 }
 
-                if (GameState->PlayersLeft == 1)
+                if (GameState->PlayersLeft == 1 && bStartedBus)
                 {
                     TArray<AFortPlayerPawn*> OutActors;
                     GetFortKismet()->STATIC_GetAllFortPlayerPawns(GetWorld(), &OutActors);


### PR DESCRIPTION
The lag after the first aircraft jump was caused by the server findobjecting the characterparts in InitPawn(). Because it's not necessary to apply the parts again after the jump, I set the default value of bResetCharacterParts to false, removing the delay.