### PR TITLE
Inventory loading from JSON

### DIFF
--- a/Raider/GameModes/GameModeBase.hpp
+++ b/Raider/GameModes/GameModeBase.hpp
@@ -1,5 +1,11 @@
 #pragma once
-#include "../ue4.h"
+
+#include <shlobj.h>
+#include <iostream>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+#include "../UE4.h"
 #include "../SDK.hpp"
 #include "../Logic/Teams.h"
 #include "../Logic/Inventory.h"
@@ -144,15 +150,35 @@ public:
     }
 
     virtual PlayerLoadout& GetPlaylistLoadout()
-    {
+    { 
         static PlayerLoadout Ret = {
-            FindWID("WID_Harvest_Pickaxe_Athena_C_T01"),
-            FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Blue Pump
-            FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Blue Pump
-            FindWID("WID_Assault_AutoHigh_Athena_SR_Ore_T03"), // Gold AR
-            FindWID("WID_Sniper_BoltAction_Scope_Athena_R_Ore_T03"), // Blue Bolt Action
-            FindWID("Athena_Shields") // Big Shield Potion
+            FindWID("WID_Harvest_Pickaxe_Athena_C_T01"), // Default Pickaxe
+            FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Rare Pump Shotgun
+            FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Rare Pump Shotgun
+            FindWID("WID_Assault_AutoHigh_Athena_SR_Ore_T03"), // Legendary Assualt Rifle
+            FindWID("WID_Sniper_BoltAction_Scope_Athena_R_Ore_T03"), // Rare Bolt Action Sniper
+            FindWID("Athena_Shields") // Shield Potion
         };
+
+        if (std::filesystem::exists("inventory.json"))
+        {
+            // Loading inventory.json from game executable directory
+            std::ifstream f("inventory.json", std::ifstream::in);
+            nlohmann::json InventoryConfig;
+
+            f >> InventoryConfig;
+
+            // Setting Items variable from InventoryConfig
+            nlohmann::json Items = InventoryConfig["items"];
+
+            // Loading each item from items array in inventory.json
+            for (int i = 0; i < 5; i++)
+            {
+                auto Item = FindWID(Items[i]);
+                // The "+1" will make sure the pickaxe will not get overwritten.
+                Ret[i + 1] = Item;
+            }
+        }
 
         return Ret;
     }

--- a/Raider/GameModes/GameModeBase.hpp
+++ b/Raider/GameModes/GameModeBase.hpp
@@ -151,7 +151,7 @@ public:
 
     virtual PlayerLoadout& GetPlaylistLoadout()
     { 
-        static PlayerLoadout Ret = {
+       static PlayerLoadout Ret = {
             FindWID("WID_Harvest_Pickaxe_Athena_C_T01"), // Default Pickaxe
             FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Rare Pump Shotgun
             FindWID("WID_Shotgun_Standard_Athena_UC_Ore_T03"), // Rare Pump Shotgun
@@ -159,24 +159,30 @@ public:
             FindWID("WID_Sniper_BoltAction_Scope_Athena_R_Ore_T03"), // Rare Bolt Action Sniper
             FindWID("Athena_Shields") // Shield Potion
         };
-
+        
         if (std::filesystem::exists("inventory.json"))
         {
             // Loading inventory.json from game executable directory
             std::ifstream f("inventory.json", std::ifstream::in);
             nlohmann::json InventoryConfig;
-
             f >> InventoryConfig;
 
             // Setting Items variable from InventoryConfig
             nlohmann::json Items = InventoryConfig["items"];
 
+            // Prevent default items from being loaded
+            Ret = {
+                FindWID("WID_Harvest_Pickaxe_Athena_C_T01"), // Default Pickaxe
+            };
+
             // Loading each item from items array in inventory.json
             for (int i = 0; i < 5; i++)
             {
-                auto Item = FindWID(Items[i]);
-                // The "+1" will make sure the pickaxe will not get overwritten.
-                Ret[i + 1] = Item;
+                if (!Items[i].is_null())
+                {
+                    auto Item = FindWID(Items[i]);
+                    Ret[i + 1] = Item;
+                }
             }
         }
 

--- a/Raider/Raider.vcxproj
+++ b/Raider/Raider.vcxproj
@@ -144,6 +144,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Gray_spdlog.1.10.0\build\native\Gray_spdlog.targets" Condition="Exists('..\packages\Gray_spdlog.1.10.0\build\native\Gray_spdlog.targets')" />
     <Import Project="..\packages\Detours.4.0.1\build\native\Detours.targets" Condition="Exists('..\packages\Detours.4.0.1\build\native\Detours.targets')" />
+    <Import Project="..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets" Condition="Exists('..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -151,5 +152,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Gray_spdlog.1.10.0\build\native\Gray_spdlog.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Gray_spdlog.1.10.0\build\native\Gray_spdlog.targets'))" />
     <Error Condition="!Exists('..\packages\Detours.4.0.1\build\native\Detours.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Detours.4.0.1\build\native\Detours.targets'))" />
+    <Error Condition="!Exists('..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets'))" />
   </Target>
 </Project>

--- a/Raider/packages.config
+++ b/Raider/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Detours" version="4.0.1" targetFramework="native" developmentDependency="true" />
   <package id="Gray_spdlog" version="1.10.0" targetFramework="native" />
+  <package id="nlohmann.json" version="3.10.5" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This is a basic implementation of loading an inventory from a JSON file. This could be useful for changing the inventory quickly without needing to recompile.

An inventory can be loaded by making a inventory.json file in the Win64 folder (the directory where Fortnite executable is stored) and making an array called items. If no file is present then the original inventory will be loaded.

The array should contain valid WIDS, e.g. WID_Shotgun_Standard_Athena_UC_Ore_T03.