### PR TITLE
Change the ReceiveDestryed hook to OnDeathServer

### DIFF
--- a/Raider/UFunctionHooks.h
+++ b/Raider/UFunctionHooks.h
@@ -148,8 +148,8 @@ namespace UFunctionHooks
             return false;
         })
 
-        DEFINE_PEHOOK("Function Engine.Actor.ReceiveDestroyed", { // TODO: Figure out why this function gets called a few seconds late. Possibly use a different one.
-            auto Actor = (AActor*)Object;
+        DEFINE_PEHOOK("Function FortniteGame.BuildingActor.OnDeathServer", {
+            auto Actor = (ABuildingActor*)Object;
 
             if (Actor)
             {


### PR DESCRIPTION
This function is called immediately, unlike ReceiveDestroyed. This fixes players being unable to place a building for a few seconds after destroying the previous one at the same spot.